### PR TITLE
fix: Critical fix for await in non-async function in libro/page.tsx

### DIFF
--- a/frontend/src/app/(protected)/libro/page.tsx
+++ b/frontend/src/app/(protected)/libro/page.tsx
@@ -143,37 +143,6 @@ export default function LibroPage({ user: initialUser }: LibroPageProps = {}) {
 
   const handleCoverUploadSuccess = (newCoverUrl: string) => {
     setCurrentBook(prevBook => prevBook ? { ...prevBook, cover_image_url: newCoverUrl, updated_at: new Date().toISOString() } : null);
-        const { data: { user: authUser } } = await supabase.auth.getUser();
-        currentUser = authUser;
-      }
-      setUser(currentUser);
-
-      if (currentUser) {
-        // Fetch book for the user. Assuming one book per user for now, or the first one.
-        // In a multi-book scenario, you'd need a way to select which book.
-        let { data: bookData, error: bookError } = await supabase
-          .from('libri')
-          .select('*')
-          .eq('user_id', currentUser.id)
-          .maybeSingle(); // Use maybeSingle if one book per user, or order/limit(1) for first
-
-        if (bookError) {
-          console.error('Errore nel recupero del libro:', bookError);
-        }
-
-        if (!bookData && !bookError) { // No book exists, create one
-          const { data: newBook, error: createError } = await supabase
-            .from('libri')
-            .insert({ user_id: currentUser.id, title: 'Il Mio Libro Vivente' }) // Default title
-            .select()
-            .single();
-
-          if (createError) {
-            console.error('Errore nella creazione del libro:', createError);
-          } else {
-            bookData = newBook;
-          }
-        }
     setShowCoverUpload(false); // Optionally close the upload UI
   };
 


### PR DESCRIPTION
This commit addresses a critical build error and consolidates all features and previous fixes.

1.  **Critical Fix in `libro/page.tsx`:**
    *   I removed an erroneously duplicated block of async data-fetching code from the synchronous `handleCoverUploadSuccess` function in `frontend/src/app/(protected)/libro/page.tsx`. This was causing multiple "await isn't allowed in non-async function" build errors.

2.  **Consolidated Features & Fixes (from previous work on this branch):**
    *   **Scope Fix for `fetchUserAndBook` in `libro/page.tsx`**:
        *   I corrected the scope of the `fetchUserAndBook` function.
    *   **TypeScript Error Fix for Button in CoverUploadClient:**
        *   I added the required `size="default"` prop.
    *   **Syntax Error Fix in ArchivioClient:**
        *   I removed extraneous closing brackets.
    *   **User Tutorial (Step 10):**
        *   I implemented a multi-step tutorial modal.
    *   **Chapter Sharing and "Mondi Paralleli" (Step 11):**
        *   I added functionality for you to share and view chapters.
    *   **Enhancements to Archive View (Step 8 & 9):**
        *   I improved the UI and logic for archived interaction sessions.
    *   **Previous Core Features (from prior work on this branch):**
        *   Responsive Header (with syntax fix).
        *   Customized Login Page & User Name Display.
        *   Backend Cold Start Optimizations.
        *   Gemini Interaction Adjustments.
        *   Seed Archiving (`raw_seed_interactions` table and logging).
        *   Cover Image Upload and Cropping.
        *   Chapter Management (Reordering, Editing, Soft Deletion).

This commit should provide a stable version with all implemented features and critical fixes, addressing the latest deployment blocker.