### PR TITLE
fix(backend): Correct rootDir for Python service in render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,6 +3,7 @@ services:
   - type: web
     name: prometheus-backend
     env: python
+    rootDir: backend # Added this line
     buildCommand: pip install -r requirements.txt
     startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
     envVars:


### PR DESCRIPTION
This commit fixes a backend deployment issue on Render.

The `prometheus-backend` service definition in `render.yaml` was missing a `rootDir` property. This caused the build command `pip install -r requirements.txt` to fail because it was looking for `requirements.txt` in the repository root instead of the `backend/` subdirectory.

Added `rootDir: backend` to the service definition to ensure Render executes build and start commands from the correct directory context. This should also ensure that `app.py` can find `semi_data.json` using a relative path.