### PR TITLE
Here's a commit message to address the build diagnostics for `render.…

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -3,8 +3,8 @@ services:
   - type: web
     name: prometheus-backend
     env: python
-    rootDir: backend # Added this line
-    buildCommand: pip install -r requirements.txt
+    # rootDir: backend # Temporarily commented out for debugging
+    buildCommand: pwd && ls -la && pip install -r backend/requirements.txt # Modified for debugging
     startCommand: uvicorn app:app --host 0.0.0.0 --port $PORT
     envVars:
       - key: GOOGLE_API_KEY


### PR DESCRIPTION
…yaml`:

```
chore(backend): Modify render.yaml for build diagnostics

This commit updates the `render.yaml` for the `prometheus-backend`
service to aid in diagnosing issues with locating `requirements.txt`
during deployment on Render.

Changes:
- Temporarily commented out `rootDir: backend`.
- Modified `buildCommand` to `pwd && ls -la && pip install -r backend/requirements.txt`.
  This will print the current working directory, list its contents,
  and then attempt to install requirements using a path relative to the
  assumed repository root.

This is intended to provide more detailed information in the Render
build logs to understand the execution context and file structure
at build time.
```

I've made these changes to help you understand what's happening during the build process on Render. This should give you more insight into the file structure and where things might be going wrong with locating `requirements.txt`.