### PR TITLE
Here's the rewritten message:

### DIFF
--- a/frontend/src/app/(protected)/scrivi/page.tsx
+++ b/frontend/src/app/(protected)/scrivi/page.tsx
@@ -225,7 +225,9 @@ export default function ScriviPage() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ 
           frasi: userMessage.content, // Matches 'frasi' in API route
-          nome: selected?.nome || semeId, // Pass 'nome' for semeId construction in API route
+          // nome: selected?.nome || semeId, // Rimuovo questa riga
+          effective_seme_id: semeId, // 'semeId' qui è quello preso dai searchParams (es. "sem_04")
+          readable_seme_name: selected?.nome,
 
           // History per il backend Python (diverso da `messages` state che ha più dettagli)
           // Il backend Python si aspetta una lista di liste: [type, content_string]

--- a/frontend/src/app/api/archetipo-gemini/route.ts
+++ b/frontend/src/app/api/archetipo-gemini/route.ts
@@ -5,37 +5,43 @@ export async function POST(req: Request) {
     const body = await req.json();
     const {
       frasi,
-      descrizione,
-      nome,
-      session_id, // Added
-      user_id,    // Added
-      interaction_number // Expecting this from frontend now
+      effective_seme_id, // Nuovo campo da ScriviPage.tsx
+      readable_seme_name, // Nuovo campo opzionale
+      session_id,
+      user_id,
+      interaction_number,
+      history,
+      is_eco_request,
+      is_first_interaction,
+      last_assistant_question
     } = body;
 
-    if (!session_id || !user_id || typeof interaction_number === 'undefined') {
-      return NextResponse.json({ error: 'session_id, user_id, and interaction_number are required' }, { status: 400 });
+    if (!session_id || !user_id || typeof interaction_number === 'undefined' || !effective_seme_id) {
+      return NextResponse.json({ error: 'session_id, user_id, interaction_number, and effective_seme_id are required' }, { status: 400 });
     }
 
     // Se frasi è già una stringa, usala, altrimenti concatena
     const userInput = Array.isArray(frasi) ? frasi.join(' • ') : frasi;
-    const semeId = `archetipo_${nome.toLowerCase().replace(/\s+/g, '_')}`; // This seems specific to "archetipo" seeds
+    // const semeId = `archetipo_${nome.toLowerCase().replace(/\s+/g, '_')}`; // RIMOSSA QUESTA RIGA
 
     // TODO: The backend's `req.seme_id` is used as `seed_archetype_id`.
-    // Ensure this `semeId` is what's intended for general seed logging, or adapt if different seeds have different ID schemes.
-    // For now, assuming `nome` (e.g. "Seme 01") is transformed into `archetipo_seme_01` and used.
-    // The backend also expects `is_eco_request` and `history` etc.
+    // effective_seme_id (es. "sem_04") è ora usato direttamente.
+    // La logica di costruzione `archetipo_...` se ancora necessaria per qualche seme specifico,
+    // dovrebbe essere gestita qui o nel backend Python in base a `effective_seme_id`.
+    // Per ora, si assume che `effective_seme_id` sia l'ID che il backend Python si aspetta.
 
     const payload = {
-      user_input: userInput,
-      seme_id: semeId, // This is used as seed_archetype_id in backend
-      is_eco_request: body.is_eco_request || false, // Pass through or default
-      history: body.history || [],                 // Pass through or default
-      interaction_number: interaction_number,      // Pass through
-      last_assistant_question: body.last_assistant_question || null, // Pass through
-
-      // Add new IDs for logging
+      user_input: userInput, // userInput viene ancora da 'frasi'
+      seme_id: effective_seme_id, // << USA effective_seme_id QUI
+      history: history || [],
+      is_eco_request: is_eco_request || false,
+      is_first_interaction: is_first_interaction !== undefined ? is_first_interaction : true,
+      interaction_number: interaction_number,
+      last_assistant_question: last_assistant_question || null,
       session_id: session_id,
-      user_id: user_id,
+      user_id: user_id
+      // readable_seme_name può essere aggiunto qui se il backend Python lo gestisce,
+      // altrimenti non è necessario inviarlo. Per ora non lo includiamo.
     };
 
     // Usa la variabile d'ambiente o fallback su localhost per lo sviluppo


### PR DESCRIPTION
Fix: Corregge gestione ID seme per API chat

Questo commit include le seguenti modifiche per risolvere l'errore 400 quando si chiama l'endpoint /api/chat del backend Python:

1.  **ScriviPage.tsx (`frontend/src/app/(protected)/scrivi/page.tsx`):**
    *   Ho modificato il payload inviato a `/api/archetipo-gemini` per includere
        `effective_seme_id` (l'ID corretto del seme, es. "sem_04") e
        `readable_seme_name` (il nome leggibile del seme).

2.  **API Route (`frontend/src/app/api/archetipo-gemini/route.ts`):**
    *   Ho aggiornato la route per estrarre `effective_seme_id` dal corpo della
        richiesta.
    *   Ora utilizzo `effective_seme_id` come `seme_id` nel payload inviato al
        backend Python.
    *   Ho rimosso la logica precedente che costruiva un `semeId` in formato
        `archetipo_...` a partire dal nome del seme.
    *   Ho aggiornato la validazione dei campi obbligatori per includere
        `effective_seme_id`.

Queste modifiche assicurano che l'ID corretto del seme venga utilizzato nella comunicazione con il backend, il che dovrebbe risolvere il problema del backend che non trovava il seme in `semi_data.json`.