### PR TITLE
Fix: Assicura che il contenuto nella history sia sempre una stringa

### DIFF
--- a/frontend/src/app/(protected)/scrivi/page.tsx
+++ b/frontend/src/app/(protected)/scrivi/page.tsx
@@ -175,7 +175,15 @@ export default function ScriviPage() {
             user_id: userId,
             session_id: sessionId,
             interaction_number: currentInteractionNumForSeme99, // Seme 99 is always first interaction in this context
-            history: [], // Seme 99 doesn't use history from this page
+            history: messages.map(m => {
+              let contentString = ""; // Default a stringa vuota
+              if (Array.isArray(m.content)) {
+                contentString = m.content.filter(item => item != null).join('\n\n');
+              } else if (m.content != null) {
+                contentString = String(m.content);
+              }
+              return [m.type, contentString];
+            }),
             last_assistant_question: null
           }),
         });
@@ -231,10 +239,15 @@ export default function ScriviPage() {
 
           // History per il backend Python (diverso da `messages` state che ha più dettagli)
           // Il backend Python si aspetta una lista di liste: [type, content_string]
-          history: messages.map(m => [
-            m.type, 
-            Array.isArray(m.content) ? m.content.join('\n\n') : m.content
-          ]),
+          history: messages.map(m => {
+            let contentString = ""; // Default a stringa vuota
+            if (Array.isArray(m.content)) {
+              contentString = m.content.filter(item => item != null).join('\n\n');
+            } else if (m.content != null) {
+              contentString = String(m.content);
+            }
+            return [m.type, contentString];
+          }),
           is_first_interaction: isFirstNormalInteraction, // Usato dal backend Python per la logica del prompt
           last_assistant_question: lastAssistantQuestion,
 


### PR DESCRIPTION
Modifica `frontend/src/app/(protected)/scrivi/page.tsx` per garantire che il campo `content` di ogni messaggio nell'array `history` (inviato all'API `/api/archetipo-gemini`) sia sempre una stringa valida. Questo previene l'invio di valori `null` o `undefined` che causavano un errore di validazione Pydantic 422 (Unprocessable Entity) nel backend Python durante la seconda interazione con il chatbot.

La logica di mappatura ora converte esplicitamente `m.content` in una stringa, usando una stringa vuota come fallback se `m.content` è `null` o `undefined`, e gestisce correttamente il caso in cui `m.content` sia un array di stringhe.