### PR TITLE
Debug: Aggiunge log per ispezionare risposta API in ScriviPage

### DIFF
--- a/frontend/src/app/(protected)/scrivi/page.tsx
+++ b/frontend/src/app/(protected)/scrivi/page.tsx
@@ -266,6 +266,10 @@ export default function ScriviPage() {
 
       const data = await response.json();
 
+      // AGGIUNGI QUESTO LOG DI DEBUG
+      console.log("DEBUG: ScriviPage - Dati ricevuti da /api/archetipo-gemini:", data);
+      // FINE LOG DI DEBUG
+
       const assistantResponse: ChatMessage = {
         type: 'assistant',
         content: data.output,


### PR DESCRIPTION
Aggiunge un console.log in `frontend/src/app/(protected)/scrivi/page.tsx` all'interno della funzione `handleSendMessage`. Questo log visualizza l'oggetto `data` completo ricevuto dalla chiamata fetch all'API `/api/archetipo-gemini`, subito dopo la sua parsificazione da JSON.

Questo vi aiuterà a determinare se i campi attesi (`output`, `eco`, `frase_finale`) sono presenti e correttamente valorizzati nella risposta ricevuta dal frontend, prima che vengano usati per costruire `assistantResponse` e successivamente passati a `handleAutoSave` per il salvataggio del capitolo.