### PR TITLE
Fix: Corregge creazione capitoli da Archivio e nomi campi

### DIFF
--- a/frontend/src/components/ArchivioClient.tsx
+++ b/frontend/src/components/ArchivioClient.tsx
@@ -268,14 +268,14 @@ export default function ArchivioClient({ user }: { user: User }) {
         .insert({
           user_id: user.id,
           titolo: finalTitle,
-          contenuto: finalContent,
+          testo: finalContent, // MODIFICATO
           seme_id: session.seedArchetypeId,
           icona: '📖',
           stato: 'bozza_da_archivio',
           raw_interaction_session_id: session.sessionId,
           eco: [],
-          frase_finale: finalTitle,
-          ordine: newOrder, // Set the new order
+          frase_finale: finalTitle
+          // 'ordine: newOrder' è stato RIMOSSO
         });
 
       if (insertError) throw insertError;


### PR DESCRIPTION
Questo commit include le seguenti correzioni e miglioramenti:

1.  **ArchivioClient.tsx (`frontend/src/app/(protected)/archivio/ArchivioClient.tsx`):**
    *   Ho corretto l'errore durante la creazione di un capitolo dalla pagina Archivio (funzione `handleCreateChapterFromSession`). Il campo per il contenuto principale è stato cambiato da `contenuto` a `testo` per corrispondere allo schema effettivo della tabella `capitoli` in Supabase.
    *   Ho rimosso il tentativo di inserire un valore per il campo `ordine`, poiché questa colonna non esiste attualmente nella tabella `capitoli`.

2.  **Logging di Debug (Mantenuto per Ora):**
    *   I `console.log` di debug in `ScriviPage.tsx` (per `handleAutoSave` e per la risposta da `/api/archetipo-gemini`) e nella route API `/api/archetipo-gemini/route.ts` (per la risposta dal backend Python) sono stati mantenuti per ulteriori verifiche post-deploy.

Queste modifiche mirano a risolvere l'errore durante la promozione di una sessione grezza a capitolo e a continuare il debug del flusso di salvataggio dati.