### PR TITLE
I plan to fix the chapter content display in LibroVivente.

### DIFF
--- a/frontend/src/app/(protected)/libro/LibroVivente.tsx
+++ b/frontend/src/app/(protected)/libro/LibroVivente.tsx
@@ -10,8 +10,8 @@ export interface Capitolo {
   id: string; // or number, depending on your schema (UUIDs are often strings)
   user_id: string;
   titolo: string;
-  contenuto: string;
-  ordine: number;
+  testo: string; // Modificato da 'contenuto'
+  // ordine: number; // RIMOSSO
   stato: string;
   seme_id?: string | null; // From which seed it originated, if any
   icona?: string | null; // Icon for the chapter
@@ -97,7 +97,7 @@ const LibroVivente = forwardRef<HTMLDivElement, LibroViventeProps>(
 
           <div className="prose prose-lg max-w-none">
             <div className="text-gray-800 leading-relaxed whitespace-pre-line text-justify">
-              {chapter.contenuto}
+              {chapter.testo} {/* Modificato da chapter.contenuto */}
             </div>
           </div>
 


### PR DESCRIPTION
I'll modify the `frontend/src/app/(protected)/libro/LibroVivente.tsx` component:
- Update the `Capitolo` interface to use `testo: string` instead of `contenuto: string`, and remove the `ordine` property which is no longer used/available.
- Update the JSX template to render `chapter.testo` instead of `chapter.contenuto`.

These changes will align the `LibroVivente` component with the actual data structure from the `capitoli` table (where the column for the chapter body is named `testo`), resolving the issue of the chapter content not being displayed.