### PR TITLE
Refactor: Implementa logica 'Manda al Libro' in ArchivioPage

### DIFF
--- a/frontend/src/components/ArchivioClient.tsx
+++ b/frontend/src/components/ArchivioClient.tsx
@@ -36,286 +36,152 @@ import {
   CopyPlus, // Icon for "Create Chapter"
   ArchiveX // Icon for no sessions
 } from 'lucide-react';
-// fetchCapitoli might be removed or adapted if this page no longer directly shows 'capitoli'
-// import { fetchCapitoli } from '@/lib/supabaseHelpers';
 import { useRouter } from 'next/navigation'; // For navigation
+import { Capitolo as CapitoloType } from '../(protected)/libro/LibroVivente'; // Import CapitoloType
 
-// Define types for raw seed interactions
+// Remove RawInteractionStep and RawInteractionSessionSummary types (or comment out)
+/*
 type RawInteractionStep = {
-  id: string; // UUID of the step itself
-  user_id: string;
-  session_id: string;
-  seed_archetype_id: string;
-  interaction_step: number;
-  interaction_type: string;
-  data: any; // JSONB, structure depends on interaction_type
-  created_at: string;
-  seed_title_generated: string | null;
-  status: string;
+  // ... (definition)
 };
 
 type RawInteractionSessionSummary = {
-  sessionId: string;
-  seedArchetypeId: string;
-  seedTitleGenerated: string | null;
-  lastInteractionDate: string;
-  interactionCount: number;
-  isInBook?: boolean; // New field
-  isDeletedFromBook?: boolean; // New field
+ // ... (definition)
 };
+*/
 
 export default function ArchivioClient({ user }: { user: User }) {
   const router = useRouter();
-  const [rawSessions, setRawSessions] = useState<RawInteractionSessionSummary[]>([]);
+  // const [rawSessions, setRawSessions] = useState<RawInteractionSessionSummary[]>([]); // OLD STATE
+  const [archiveChapters, setArchiveChapters] = useState<CapitoloType[]>([]); // NEW STATE
   const [loading, setLoading] = useState(true);
-  // const [authLoading, setAuthLoading] = useState(false); // Kept if needed for other auth actions
-  // Editing and transfer states might be removed or re-purposed if editing happens on a different page
-  // const [editingId, setEditingId] = useState<number | null>(null);
-  // const [editForm, setEditForm] = useState<EditingCapitolo | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [error, setError] = useState<string | null>(null);
-  const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set()); // Use sessionId (string)
-  const [promotingToChapter, setPromotingToChapter] = useState<string | null>(null); // Store sessionId being promoted
+  const [expandedCards, setExpandedCards] = useState<Set<string>>(new Set()); // Use chapter.id (string)
+  // const [promotingToChapter, setPromotingToChapter] = useState<string | null>(null); // For new "Manda al Libro" logic
+  const [processingChapterId, setProcessingChapterId] = useState<string | null>(null); // General processing state
 
   const supabase = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
   );
 
-  const loadRawInteractionSessions = useCallback(async (userId: string) => {
+  // Renamed and refactored function
+  const loadArchiveChapters = useCallback(async (userId: string) => {
     try {
       setLoading(true);
       setError(null);
 
-      // 1. Fetch all raw interactions for the user
-      const { data: rawInteractionsData, error: fetchError } = await supabase
-        .from('raw_seed_interactions')
-        .select('session_id, seed_archetype_id, seed_title_generated, created_at, interaction_step')
+      const { data: chapterData, error: fetchError } = await supabase
+        .from('capitoli')
+        .select('*') // Select all fields, or specific ones matching CapitoloType + created_at/updated_at
         .eq('user_id', userId)
-        .order('created_at', { ascending: false });
+        .in('stato', ['bozza_in_archivio', 'promosso_al_libro'])
+        .order('created_at', { ascending: false }); // Assuming 'created_at' for ordering
 
       if (fetchError) throw fetchError;
-      if (!rawInteractionsData) {
-        setRawSessions([]);
-        setLoading(false);
-        return;
-      }
 
-      // 2. Fetch 'capitoli' that are linked to raw_interaction_session_id
-      const { data: bookChapters, error: chaptersError } = await supabase
-        .from('capitoli')
-        .select('raw_interaction_session_id, stato')
-        .eq('user_id', userId)
-        .in('stato', ['nel_libro', 'archivio_cancellato'])
-        .not('raw_interaction_session_id', 'is', null); // Corrected syntax
-
-      if (chaptersError) throw chaptersError;
-
-      const inBookSessionIds = new Set<string>();
-      const deletedFromBookSessionIds = new Set<string>();
-
-      if (bookChapters) {
-        bookChapters.forEach(chapter => {
-          if (chapter.raw_interaction_session_id) {
-            if (chapter.stato === 'nel_libro') {
-              inBookSessionIds.add(chapter.raw_interaction_session_id);
-            } else if (chapter.stato === 'archivio_cancellato') {
-              deletedFromBookSessionIds.add(chapter.raw_interaction_session_id);
-            }
-          }
-        });
-      }
-
-      // 3. Process raw interactions into session summaries
-      const sessionsMap = new Map<string, RawInteractionSessionSummary>();
-      rawInteractionsData.forEach(item => {
-        let sessionSummary = sessionsMap.get(item.session_id);
-        if (!sessionSummary) {
-          sessionSummary = {
-            sessionId: item.session_id,
-            seedArchetypeId: item.seed_archetype_id,
-            seedTitleGenerated: item.seed_title_generated,
-            lastInteractionDate: item.created_at,
-            interactionCount: 0, // Will be incremented
-            isInBook: inBookSessionIds.has(item.session_id) && !deletedFromBookSessionIds.has(item.session_id),
-            isDeletedFromBook: deletedFromBookSessionIds.has(item.session_id),
-          };
-        }
-
-        sessionSummary.interactionCount += 1;
-        // Update last interaction date if this item is newer
-        if (new Date(item.created_at) > new Date(sessionSummary.lastInteractionDate)) {
-          sessionSummary.lastInteractionDate = item.created_at;
-        }
-        // Update title if this item has one and current summary doesn't, or if this item is later and has a title
-        if (item.seed_title_generated && (!sessionSummary.seedTitleGenerated || new Date(item.created_at) >= new Date(sessionSummary.lastInteractionDate))) {
-          sessionSummary.seedTitleGenerated = item.seed_title_generated;
-        }
-        // Ensure flags are updated if processing multiple items for the same session
-        sessionSummary.isInBook = inBookSessionIds.has(item.session_id) && !deletedFromBookSessionIds.has(item.session_id);
-        sessionSummary.isDeletedFromBook = deletedFromBookSessionIds.has(item.session_id);
-
-        sessionsMap.set(item.session_id, sessionSummary);
-      });
-
-      const sortedSessions = Array.from(sessionsMap.values()).sort(
-        (a, b) => new Date(b.lastInteractionDate).getTime() - new Date(a.lastInteractionDate).getTime()
-      );
-      setRawSessions(sortedSessions);
+      setArchiveChapters(chapterData || []);
 
     } catch (err) {
-      console.error('Error loading raw interaction sessions or chapters:', err);
+      console.error('Error loading archive chapters:', err);
       const supabaseError = err as any;
       setError(`Errore nel caricamento dell'archivio: ${supabaseError.message || 'Errore sconosciuto'}`);
     } finally {
       setLoading(false);
     }
-  }, [supabase]); // Removed user from dependencies as it's passed directly
+  }, [supabase]);
 
   useEffect(() => {
     if (user?.id) {
-      loadRawInteractionSessions(user.id);
+      loadArchiveChapters(user.id);
     }
-  }, [user, loadRawInteractionSessions]);
+  }, [user, loadArchiveChapters]);
 
-  const toggleCardExpansion = (sessionId: string) => {
+  const toggleCardExpansion = (chapterId: string) => {
     const newExpanded = new Set(expandedCards);
-    if (newExpanded.has(sessionId)) {
-      newExpanded.delete(sessionId);
+    if (newExpanded.has(chapterId)) {
+      newExpanded.delete(chapterId);
     } else {
-      newExpanded.add(sessionId);
+      newExpanded.add(chapterId);
     }
     setExpandedCards(newExpanded);
   };
 
-  const handleViewSessionDetails = (sessionId: string) => {
-    // For now, just log. Later, navigate to a detail page:
-    // router.push(`/archivio/${sessionId}`);
-    console.log("View details for session:", sessionId);
-    // As a quick way to see details, we can expand the card or show a modal here too.
-    // For this step, clicking the card title area will serve as "view details" by expanding it.
-    toggleCardExpansion(sessionId);
-  };
-
+  // Temporarily comment out or simplify handleCreateChapterFromSession
+  /*
   const handleCreateChapterFromSession = async (session: RawInteractionSessionSummary) => {
-    if (!user) return;
-    setPromotingToChapter(session.sessionId);
-    setError(null);
+    // ... (old logic) ...
+  };
+  */
 
+  const handleSendChapterToBook = async (chapter: CapitoloType) => {
+    if (!user) {
+      toast.error("Utente non autenticato.");
+      return;
+    }
+    setProcessingChapterId(chapter.id);
     try {
-      // 1. Fetch all interactions for this session to get the final content
-      const { data: interactions, error: fetchError } = await supabase
-        .from('raw_seed_interactions')
-        .select('interaction_type, data, seed_title_generated')
-        .eq('user_id', user.id)
-        .eq('session_id', session.sessionId)
-        .order('interaction_step', { ascending: true }); // Important to get steps in order
+      // 1. Insert into 'libro' table
+      const libroInsertData = {
+        user_id: chapter.user_id,
+        seme_id: chapter.seme_id || null, // Handle optional seme_id
+        titolo: chapter.titolo,
+        testo: chapter.testo,
+        sottotitolo: (chapter.eco && chapter.eco.length > 0) ? chapter.eco.join(', ') : '',
+        timestamp: new Date().toISOString(),
+        // ordine: undefined, // Omit for now
+      };
 
-      if (fetchError) throw fetchError;
-      if (!interactions || interactions.length === 0) {
-        throw new Error("Nessuna interazione trovata per questa sessione.");
+      const { error: insertLibroError } = await supabase
+        .from('libro') // Target table for the main book
+        .insert(libroInsertData);
+
+      if (insertLibroError) {
+        console.error("Errore inserimento in 'libro':", insertLibroError);
+        toast.error(`Errore durante l'invio al libro: ${insertLibroError.message}`);
+        return; // Stop if this fails
       }
 
-      // 2. Extract title and final content
-      // Title is from summary, or find the last one set in the interactions.
-      let finalTitle = session.seedTitleGenerated;
-      let finalContent = "";
-
-      // Iterate backwards to find the last gemini_response with content and potentially a title
-      for (let i = interactions.length - 1; i >= 0; i--) {
-        const step = interactions[i];
-        if (step.interaction_type.startsWith('gemini_response_')) {
-          if (step.data?.parsed_output) {
-            finalContent = Array.isArray(step.data.parsed_output)
-              ? step.data.parsed_output.join('\n\n')
-              : step.data.parsed_output;
-          }
-          if (step.seed_title_generated && !finalTitle) { // Prioritize title from the step if summary didn't have one
-            finalTitle = step.seed_title_generated;
-          }
-          if (finalContent) break; // Found the main content
-        }
-      }
-      
-      if (!finalTitle) {
-         // Fallback title if none was explicitly generated/found
-        finalTitle = `Capitolo da ${session.seedArchetypeId}`;
-      }
-      if (!finalContent) {
-        // Fallback content if no Gemini output found (should not happen in normal flow)
-        finalContent = "Contenuto non ancora generato o sessione incompleta.";
-      }
-
-      // Fetch current max 'ordine' for this user's chapters
-      const { data: maxOrderData, error: maxOrderError } = await supabase
+      // 2. Update 'capitoli' table
+      const { error: updateCapitoloError } = await supabase
         .from('capitoli')
-        .select('ordine')
-        .eq('user_id', user.id)
-        .is('ordine', 'not.null') // Ensure we only consider rows where ordine is set
-        .order('ordine', { ascending: false })
-        .limit(1)
-        .maybeSingle();
+        .update({
+          stato: 'promosso_al_libro',
+          updated_at: new Date().toISOString(),
+        })
+        .eq('id', chapter.id);
 
-      if (maxOrderError) {
-        // Log the error but proceed, newOrder will be 0 in this case
-        console.warn('Could not reliably determine max order for chapters, defaulting new chapter order. Error:', maxOrderError.message);
+      if (updateCapitoloError) {
+        console.error("Errore aggiornamento 'capitoli':", updateCapitoloError);
+        toast.error(`Errore durante l'aggiornamento dello stato del capitolo: ${updateCapitoloError.message}`);
+        // Consider a rollback or compensating action for the 'libro' insert if critical
+        return;
       }
-      const newOrder = (maxOrderData?.ordine ?? -1) + 1;
 
-      // 3. Create new chapter in 'capitoli' table
-      const { error: insertError } = await supabase
-        .from('capitoli')
-        .insert({
-          user_id: user.id,
-          titolo: finalTitle,
-          testo: finalContent, // MODIFICATO
-          seme_id: session.seedArchetypeId,
-          icona: '📖',
-          stato: 'bozza_da_archivio',
-          raw_interaction_session_id: session.sessionId,
-          eco: [],
-          frase_finale: finalTitle
-          // 'ordine: newOrder' è stato RIMOSSO
-        });
-
-      if (insertError) throw insertError;
-
-      // 4. Optionally, update status of raw_seed_interactions
-      // This is a nice-to-have, can be skipped if complex due to RLS or policies
-      // await supabase.from('raw_seed_interactions').update({ status: 'copied_to_capitoli' })
-      //   .eq('session_id', session.sessionId);
-
-      alert(`Capitolo "${finalTitle}" creato e pronto per la modifica nel Libro!`);
-      // Optionally, redirect to the book editing page or refresh current list
-      // router.push(`/libro?editingChapterId=${newChapterId}`); // if newChapterId is returned
+      toast.success(`Capitolo "${chapter.titolo}" inviato al libro con successo!`);
+      loadArchiveChapters(user.id); // Refresh the list
 
     } catch (err: any) {
-      console.error('Errore durante la creazione del capitolo:', err);
-      setError(`Errore creazione capitolo: ${err.message || 'Sconosciuto'}`);
+      console.error('Errore generico in handleSendChapterToBook:', err);
+      toast.error(`Si è verificato un errore imprevisto: ${err.message || 'Sconosciuto'}`);
     } finally {
-      setPromotingToChapter(null);
+      setProcessingChapterId(null);
     }
   };
 
-
-
-  const sessionsInBook = rawSessions.filter(s => s.isInBook && !s.isDeletedFromBook);
-  const otherArchivedSessions = rawSessions.filter(s => !s.isInBook || s.isDeletedFromBook);
-
-  // Apply search term to both lists
-  const filterLogic = (session: RawInteractionSessionSummary) =>
-    (session.seedArchetypeId && session.seedArchetypeId.toLowerCase().includes(searchTerm.toLowerCase())) ||
-    (session.seedTitleGenerated && session.seedTitleGenerated.toLowerCase().includes(searchTerm.toLowerCase()));
-
-  const filteredSessionsInBook = sessionsInBook.filter(filterLogic);
-  const filteredOtherArchivedSessions = otherArchivedSessions.filter(filterLogic);
-
+  // Filtering logic based on new state 'archiveChapters'
+  const filteredArchiveChapters = archiveChapters.filter(chapter =>
+    (chapter.titolo && chapter.titolo.toLowerCase().includes(searchTerm.toLowerCase())) ||
+    (chapter.testo && chapter.testo.toLowerCase().includes(searchTerm.toLowerCase())) ||
+    (chapter.seme_id && chapter.seme_id.toLowerCase().includes(searchTerm.toLowerCase()))
+  );
 
   if (loading) {
     return (
       <div className="flex flex-col items-center justify-center min-h-screen space-y-4">
         <Loader2 className="h-8 w-8 animate-spin text-primary" />
-        <p className="text-sm text-muted-foreground">Caricamento archivio interazioni...</p>
+        <p className="text-sm text-muted-foreground">Caricamento archivio capitoli...</p>
       </div>
     );
   }
@@ -329,7 +195,7 @@ export default function ArchivioClient({ user }: { user: User }) {
           </CardHeader>
           <CardContent className="text-center space-y-4">
             <p className="text-muted-foreground">{error}</p>
-            <Button variant="default" size="default" className="" onClick={() => user?.id && loadRawInteractionSessions(user.id)}>
+            <Button variant="default" size="default" onClick={() => user?.id && loadArchiveChapters(user.id)}>
               Riprova Caricamento
             </Button>
           </CardContent>
@@ -338,34 +204,32 @@ export default function ArchivioClient({ user }: { user: User }) {
     );
   }
 
-  const renderSessionCard = (session: RawInteractionSessionSummary, isBookContext: boolean) => {
-    const isExpanded = expandedCards.has(session.sessionId);
-    const buttonDisabled = (isBookContext && !session.isDeletedFromBook) || promotingToChapter === session.sessionId;
-    let buttonText = "Crea Capitolo da questa Interazione";
-    if (isBookContext && !session.isDeletedFromBook) {
-      buttonText = "Già nel Libro";
-    } else if (session.isDeletedFromBook) {
-      buttonText = "Ricrea Capitolo (da sessione archiviata)";
-    }
-
+  // Renamed and refactored card rendering function
+  const renderArchiveChapterCard = (chapter: CapitoloType) => {
+    const isExpanded = expandedCards.has(chapter.id);
+    const isPromoted = chapter.stato === 'promosso_al_libro';
+    // const isProcessing = promotingToChapter === chapter.id; // For future "Manda al Libro"
+    const isProcessing = processingChapterId === chapter.id;
 
     return (
-      <Card key={session.sessionId} className={`overflow-hidden transition-all duration-200 ${isBookContext && !session.isDeletedFromBook ? 'border-green-500' : (session.isDeletedFromBook ? 'border-orange-400' : '')}`}>
-        <CardHeader className="pb-3 cursor-pointer" onClick={() => handleViewSessionDetails(session.sessionId)}>
+      <Card key={chapter.id} className={`overflow-hidden transition-all duration-200 ${isPromoted ? 'border-green-500' : ''}`}>
+        <CardHeader className="pb-3 cursor-pointer" onClick={() => toggleCardExpansion(chapter.id)}>
           <div className="flex items-start justify-between">
             <CardTitle className="flex items-center gap-3 flex-1 group">
-              <span className="text-2xl">💬</span>
+              <span className="text-2xl">{chapter.icona || '📖'}</span>
               <span className="group-hover:text-primary transition-colors">
-                {session.seedTitleGenerated || session.seedArchetypeId}
+                {chapter.titolo}
               </span>
               <div className="ml-auto flex items-center gap-2">
-                {session.isDeletedFromBook && <Badge variant="outline" className="border-orange-400 text-orange-500">Rimosso dal Libro</Badge>}
-                {isBookContext && !session.isDeletedFromBook && <Badge variant="default" className="bg-green-600 hover:bg-green-700">Nel Libro</Badge>}
-                <Badge variant="outline">Interazioni: {session.interactionCount}</Badge>
-                <Badge variant="secondary" className="gap-1">
-                  <Calendar className="h-3 w-3" />
-                  {new Date(session.lastInteractionDate).toLocaleDateString()}
-                </Badge>
+                {isPromoted && <Badge variant="default" className="bg-green-600 hover:bg-green-700">Nel Libro</Badge>}
+                {!isPromoted && <Badge variant="outline">Bozza ({chapter.stato})</Badge>}
+                {chapter.seme_id && <Badge variant="secondary">{chapter.seme_id}</Badge>}
+                {chapter.created_at && (
+                  <Badge variant="outline" className="gap-1">
+                    <Calendar className="h-3 w-3" />
+                    {new Date(chapter.created_at).toLocaleDateString()}
+                  </Badge>
+                )}
                 {isExpanded ? (
                   <ChevronUp className="h-4 w-4 text-muted-foreground" />
                 ) : (
@@ -378,27 +242,30 @@ export default function ArchivioClient({ user }: { user: User }) {
 
         {isExpanded && (
           <CardContent className="space-y-4 animate-in slide-in-from-top-2 duration-200">
-            <p className="text-sm text-muted-foreground">
-              ID Sessione: {session.sessionId} <br />
-              Archetipo Seme: {session.seedArchetypeId}
+            <p className="text-sm text-muted-foreground line-clamp-3">
+              {chapter.testo}
             </p>
-            <Button
-              onClick={() => handleCreateChapterFromSession(session)}
-              disabled={buttonDisabled}
-              variant={isBookContext && !session.isDeletedFromBook ? "secondary" : "default"}
-              size="sm"
-              className="gap-2"
-            >
-              {promotingToChapter === session.sessionId ? (
-                <Loader2 className="h-4 w-4 animate-spin" />
-              ) : (
-                <CopyPlus className="h-4 w-4" />
-              )}
-              {buttonText}
-            </Button>
-            <p className="text-xs text-center italic mt-2">
-              (La visualizzazione dettagliata dei passaggi dell'interazione sarà implementata qui o in una pagina dedicata.)
-            </p>
+            {chapter.raw_interaction_session_id && (
+              <p className="text-xs text-muted-foreground">ID Sessione Originale: {chapter.raw_interaction_session_id}</p>
+            )}
+
+            {!isPromoted && chapter.stato === 'bozza_in_archivio' ? (
+              <Button
+                onClick={() => handleSendChapterToBook(chapter)}
+                disabled={isProcessing} // Disable if this specific chapter is being processed
+                size="sm"
+                className="gap-2"
+              >
+                {isProcessing ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <ArrowRight className="h-4 w-4" />
+                )}
+                Manda al Libro
+              </Button>
+            ) : (
+              <p className="text-sm font-medium text-green-600">Questo capitolo è già nel tuo libro.</p>
+            )}
           </CardContent>
         )}
       </Card>
@@ -408,16 +275,16 @@ export default function ArchivioClient({ user }: { user: User }) {
   return (
     <div className="container mx-auto py-8 px-4 space-y-6">
       <div className="text-center space-y-4">
-        <h1 className="text-4xl font-bold gradient-text">📜 Archivio Interazioni Grezze</h1>
+        <h1 className="text-4xl font-bold gradient-text">📜 Archivio Bozze Capitoli</h1>
         <p className="text-lg text-muted-foreground max-w-2xl mx-auto">
-          Rivedi le tue sessioni di interazione con i semi e promuovile a capitoli del tuo libro.
+          Rivedi le tue bozze generate automaticamente e promuovile al tuo libro principale.
         </p>
       </div>
 
       <div className="flex flex-col sm:flex-row gap-4 items-center justify-between">
         <div className="flex-1 w-full sm:max-w-md">
           <Input
-            placeholder="🔍 Cerca per ID Seme o Titolo..."
+            placeholder="🔍 Cerca per Titolo, Testo o ID Seme..."
             value={searchTerm}
             onChange={(e) => setSearchTerm(e.target.value)}
             className="w-full"
@@ -425,48 +292,20 @@ export default function ArchivioClient({ user }: { user: User }) {
         </div>
       </div>
 
-      {/* Summary Cards - can be re-enabled or adjusted as needed */}
-      {/* ... */}
-
-      {/* Section for Sessions Already in Book */}
-      {filteredSessionsInBook.length > 0 && (
-        <div className="space-y-4 mt-8 pt-6 border-t">
-          <h2 className="text-2xl font-semibold">Sessioni Già nel Libro</h2>
-          {filteredSessionsInBook.map(session => renderSessionCard(session, true))}
-        </div>
-      )}
-
-      {/* Section for Other Archived Sessions */}
       <div className="space-y-4 mt-8 pt-6 border-t">
-         <h2 className="text-2xl font-semibold">Altre Sessioni Archiviate</h2>
-        {filteredOtherArchivedSessions.length === 0 && rawSessions.length > 0 && !loading && (
+        {filteredArchiveChapters.length === 0 && !loading && (
            <Card className="py-12">
             <CardContent className="text-center space-y-4">
               <ArchiveX className="h-16 w-16 text-muted-foreground mx-auto" />
-              <h3 className="text-xl font-semibold">Nessuna altra sessione archiviata</h3>
+              <h3 className="text-xl font-semibold">Nessun capitolo archiviato trovato</h3>
               <p className="text-muted-foreground">
-                {searchTerm ? 'Nessun risultato per la ricerca attuale in questa sezione.' : 'Tutte le sessioni sono visualizzate sopra o non ci sono altre sessioni.'}
+                {searchTerm ? 'Nessun risultato per la ricerca attuale.' : 'Non hai ancora capitoli in stato di bozza o promossi al libro.'}
               </p>
             </CardContent>
           </Card>
         )}
-        {filteredOtherArchivedSessions.length > 0 &&
-          filteredOtherArchivedSessions.map(session => renderSessionCard(session, false))
-        }
+        {filteredArchiveChapters.map(chapter => renderArchiveChapterCard(chapter))}
       </div>
-
-
-      {(rawSessions.length === 0 && !loading) && (
-         <Card className="py-12">
-            <CardContent className="text-center space-y-4">
-              <ArchiveX className="h-16 w-16 text-muted-foreground mx-auto" />
-              <h3 className="text-xl font-semibold">Nessuna interazione trovata</h3>
-              <p className="text-muted-foreground">
-                Non hai ancora sessioni di interazione registrate. Inizia un dialogo con un seme!
-              </p>
-            </CardContent>
-          </Card>
-      )}
     </div>
   );
 }

--- a/frontend/src/components/ArchivioClient.tsx
+++ b/frontend/src/components/ArchivioClient.tsx
@@ -37,7 +37,7 @@ import {
   ArchiveX // Icon for no sessions
 } from 'lucide-react';
 import { useRouter } from 'next/navigation'; // For navigation
-import { Capitolo as CapitoloType } from '../(protected)/libro/LibroVivente'; // Import CapitoloType
+import { Capitolo as CapitoloType } from '@/app/(protected)/libro/LibroVivente'; // Import CapitoloType
 
 // Remove RawInteractionStep and RawInteractionSessionSummary types (or comment out)
 /*


### PR DESCRIPTION
Modifica `frontend/src/app/(protected)/archivio/ArchivioClient.tsx`:
- Ora legge i capitoli dalla tabella `capitoli` filtrando per stato 'bozza_in_archivio' o 'promosso_al_libro'.
- La visualizzazione delle card è stata aggiornata per riflettere i dati dei capitoli e il loro stato (Bozza / Nel Libro).
- Implementata la funzione `handleSendChapterToBook`:
  - Quando un capitolo 'bozza_in_archivio' viene 'mandato al libro':
    1. Crea un nuovo record nella tabella `libro` con i dati del capitolo (mappando `eco` a `sottotitolo`). Il campo `ordine` è omesso per ora in attesa della sua aggiunta al DB.
    2. Se l'inserimento in `libro` ha successo, aggiorna lo `stato` del capitolo originale in `capitoli` a `'promosso_al_libro'`.
  - La vecchia logica `handleCreateChapterFromSession` (che creava capitoli da `raw_seed_interactions`) è stata rimossa/commentata.

Questa modifica allinea la pagina Archivio al flusso desiderato, permettendo la promozione di bozze dalla tabella `capitoli` alla tabella `libro` finale.