### PR TITLE
Fix: Correct FastAPI app initialization order

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -221,6 +221,22 @@ JSON:
         task_results[task_id] = {"status": "failed", "error": error_detail, "status_code": status_code}
 
 
+# Inizializzazione dell'applicazione FastAPI
+app = FastAPI(lifespan=lifespan)
+
+# Configurazione CORS più sicura per la produzione
+# In produzione, usa la variabile d'ambiente FRONTEND_URL o consenti tutti gli origini in sviluppo
+frontend_url = os.getenv("FRONTEND_URL", "http://localhost:3000")
+allow_origins = [frontend_url] if frontend_url != "*" else ["*"]
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=allow_origins,
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
 # Endpoint principale della chat (ora asincrono)
 @app.post("/api/chat")
 async def chat_endpoint(req: ChatRequest, background_tasks: BackgroundTasks):


### PR DESCRIPTION
- Moved the `app = FastAPI(...)` initialization and CORS middleware setup to a position before any endpoint decorators (`@app.post`, `@app.get`) are used.
- This resolves a `NameError: name 'app' is not defined` that occurred during server startup due to incorrect statement order after the async refactoring.